### PR TITLE
fix Call to undefined method WP_Image_Editor_Imagick::get_error_message()

### DIFF
--- a/libs/aq_resizer/aq_resizer.php
+++ b/libs/aq_resizer/aq_resizer.php
@@ -141,9 +141,16 @@ if(!class_exists('Aq_Resize')) {
 
                         $editor = wp_get_image_editor( $img_path );
 
-                        if ( is_wp_error( $editor ) || is_wp_error( $editor->resize( $width, $height, $crop ) ) ) {
+                        if ( is_wp_error( $editor ) ) {
                             throw new Aq_Exception('Unable to get WP_Image_Editor: ' .
                                                    $editor->get_error_message() . ' (is GD or ImageMagick installed?)');
+                        }
+
+                        $resize = $editor->resize( $width, $height, $crop );
+
+                        if ( is_wp_error( $resize ) ) {
+                            throw new Aq_Exception('Unable to resize: ' .
+                                                   $resize->get_error_message());
                         }
 
                         $resized_file = $editor->save();


### PR DESCRIPTION
When using too big image size - resize error should be, not editor error